### PR TITLE
Handle annotations and locations better

### DIFF
--- a/src/lyet.erl
+++ b/src/lyet.erl
@@ -29,8 +29,8 @@
 -define(ERROR(R, T, F, I),
         begin
             rpt_error(R, T, F, I),
-            throw({error,erl_syntax:get_pos(
-                           proplists:get_value(form,I)),{unknown,R}})
+            throw({error,erl_anno:location(get_pos(
+                           proplists:get_value(form,I))),{unknown,R}})
         end).
 
 -import(erl_syntax, [clause/3,
@@ -62,14 +62,14 @@ parse_transform(Forms, Options) ->
                     [Expr|Assignments] = lists:reverse(L),
                     lists:foldl 
                       (fun (Assign, Acc) ->
-                         { match, Line, Pattern, Val } = 
+                         { match, Anno, Pattern, Val } = 
                            erl_syntax:revert (Assign),
                          { call,
-                           Line,
+                           Anno,
                            { 'fun',
-                             Line,
+                             Anno,
                              { clauses,
-                               [ { clause, Line, [ Pattern ], [], [ Acc ] } ]
+                               [ { clause, Anno, [ Pattern ], [], [ Acc ] } ]
                              }
                            },
                            [ Val ]


### PR DESCRIPTION
This PR is one of several affecting repositories on Github. It
aims at fixing bad use of annotations (see erl_anno(3)). The
following remarks are common to all PR:s.

Typically the second element of abstract code tuples is assumed
to be an integer, which is no longer always true. For instance,
the parse transform implementing QLC tables (see qlc(3)) returns
code where some annotations are marked as `generated'. Such an
annotation is a list, not an integer (it used to be a negative
integer).

As of Erlang/OTP 24.0, the location can be a tuple {Line, Column},
which is another reason to handle annotations properly.